### PR TITLE
Fixed depracation warnings in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "java"
+    id "java-library"
     id "org.sonarqube" version "2.7"
     id 'maven-publish'
     id 'signing'
@@ -24,10 +24,10 @@ repositories {
 
 
 dependencies {
-    testCompile 'org.codehaus.groovy:groovy-all:2.3.7'
-    testCompile 'org.jmockit:jmockit:1.20'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.slf4j:slf4j-simple:1.7.13'
+    testImplementation 'org.codehaus.groovy:groovy-all:2.3.7'
+    testImplementation 'org.jmockit:jmockit:1.20'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.13'
 }
 
 sonarqube {

--- a/build.gradle
+++ b/build.gradle
@@ -40,12 +40,12 @@ sonarqube {
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava
-    classifier = 'sources'
+    archiveClassifier = 'sources'
 }
 
 task javadocJar(type: Jar) {
     from javadoc
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
 }
 
 publishing {


### PR DESCRIPTION
<!-- !************* PLEASE READ COMPLETELY *************! 

Thanks for contributing! 

Please use following guide for properly describe your contribution. 

Issue Link - add link to Jira, github or any design document which explains reasoning behind this change.
Software engineers can read and understand code and the issue should finilize parts which DOES NOT implemented.
It should explain rationaly and design decisions. 

Brief explanation of a change - explain change from hightlevel details to specifics.
Configuration options, adoption steps and flags needs to be mentionied here.


Will it break existing clients and code in production - simple yes/no answer.
Mostly it speaks about API compatibility, however it is not limited by it alone.
Behavior change as well as impact on dependencies should be reflected here as well. 

-->

**1. Issue Link:** 
https://github.com/intuit/Traverser/issues/13


**2. Brief explanation of a change:** 
The use of java plugin in the build.gradle file as well as using testCompile have been deprecated in gradle. In order to remedy the first issue I replaced the java plugin with the java-library plugin. There are a few plugins that build on top of the java plugin and it is recommended by the Gradle team to use one such plugin instead of the java plugin. The java-library was the most appropriate for this project since the project is a library and its is going to be used in other projects.

In order to remedy the second issue I replaced all cases of testCompile with testImplementation which is a solution that is recommended by the Gradle team.

I used the following sources in order to make the changes mentioned:
1. https://www.youtube.com/watch?v=nHXy2due_fA&t=807s (A webinar hosted by the Gradle team on Youtube)
2. https://docs.gradle.org/current/userguide/java_library_plugin.html (The official documentation on the java-library plugin)

**3. Will it break existing clients and code in production?**
No
